### PR TITLE
HW5

### DIFF
--- a/h2/pom.xml
+++ b/h2/pom.xml
@@ -141,7 +141,25 @@
       <scope>test</scope>
     </dependency>
     <!-- END TEST DEPENDENCIES !-->
+
+    <!-- Mockito Core (for unit tests) -->
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>5.7.0</version>
+      <scope>test</scope>
+    </dependency>
+
+    <!-- Mockito JUnit 5 Extension (if using JUnit 5) -->
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-junit-jupiter</artifactId>
+      <version>5.7.0</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
+
+
 
   <!-- The test code creates proxy files using javac or tools.jar. Through maven we need to tell it
        where to possibly find tools.jar and annoyingly its called classes.jar on OSX -->

--- a/h2/pom.xml
+++ b/h2/pom.xml
@@ -38,6 +38,8 @@
 
   <properties>
     <maven.compiler.release>11</maven.compiler.release>
+    <maven.compiler.source>19</maven.compiler.source>
+    <maven.compiler.target>19</maven.compiler.target>
     <asm.version>9.5</asm.version>
     <jts.version>1.19.0</jts.version>
     <junit.version>5.10.0</junit.version>
@@ -65,7 +67,21 @@
   </dependencyManagement>
 
   <dependencies>
+    <!-- Mockito Core (for unit tests) -->
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>5.7.0</version>
+      <scope>test</scope>
+    </dependency>
 
+    <!-- Mockito JUnit 5 Extension (if using JUnit 5) -->
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-junit-jupiter</artifactId>
+      <version>5.7.0</version>
+      <scope>test</scope>
+    </dependency>
     <!-- START COMPILE DEPENDENCIES !-->
     <dependency>
       <groupId>javax.servlet</groupId>
@@ -141,25 +157,7 @@
       <scope>test</scope>
     </dependency>
     <!-- END TEST DEPENDENCIES !-->
-
-    <!-- Mockito Core (for unit tests) -->
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
-      <version>5.7.0</version>
-      <scope>test</scope>
-    </dependency>
-
-    <!-- Mockito JUnit 5 Extension (if using JUnit 5) -->
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-junit-jupiter</artifactId>
-      <version>5.7.0</version>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
-
-
 
   <!-- The test code creates proxy files using javac or tools.jar. Through maven we need to tell it
        where to possibly find tools.jar and annoyingly its called classes.jar on OSX -->

--- a/h2/src/main/org/h2/command/query/Optimizer.java
+++ b/h2/src/main/org/h2/command/query/Optimizer.java
@@ -82,7 +82,9 @@ class Optimizer {
         } else {
             startNs = System.nanoTime();
             if (filters.length <= MAX_BRUTE_FORCE_FILTERS) {
-                calculateBruteForceAll(isSelectCommand);
+                RuleBasedJoinOrderPicker ruleBasedJoinOrderPicker = new RuleBasedJoinOrderPicker(session, filters);
+                TableFilter[] ruleBasedResult = ruleBasedJoinOrderPicker.bestOrder();
+                testPlan(ruleBasedResult, isSelectCommand);
             } else {
                 calculateBruteForceSome(isSelectCommand);
                 random = new Random(0);

--- a/h2/src/main/org/h2/command/query/RuleBasedJoinOrderPicker.java
+++ b/h2/src/main/org/h2/command/query/RuleBasedJoinOrderPicker.java
@@ -26,7 +26,6 @@ public class RuleBasedJoinOrderPicker {
         List<TableFilter> tableFilterList = new ArrayList<>(Arrays.asList(filters));
 
 
-//        Arrays.sort(filtersSorted, (a, b) -> Long.compare(a.getTable().getRowCountApproximation(session), b.getTable().getRowCountApproximation(session)));
         String conditionString = "";
         if (filters.length > 0) {
             TableFilter temp = filters[0];
@@ -44,7 +43,6 @@ public class RuleBasedJoinOrderPicker {
         while (matcher.find()) {
             String conditionInsideParentheses = matcher.group(1);   // only get inside of parenthesis
             conditions.add(conditionInsideParentheses);
-//            System.out.println("Condition added: " + conditionInsideParentheses);
         }
 
         List<TableFilter> toRevisit = new ArrayList<>();                   // store Cartesian products here
@@ -65,7 +63,6 @@ public class RuleBasedJoinOrderPicker {
                     }
                     if (condition.contains(tableName) &&  condition.contains(tableNamePrev)) {
                         conditionSatisfied = true;
-//                        System.out.println("Conditions is satisfied: " + conditionSatisfied);
                         break;
                     }
                 }
@@ -74,28 +71,16 @@ public class RuleBasedJoinOrderPicker {
                 conditionSatisfied = true;
             }
             if (conditionSatisfied) {
-//                System.out.println("Filter: " + tableName + " is in " + conditionString);
                 list[insertIndex] = tableFilterList.get(0);
                 insertIndex++;
                 tableFilterList.remove(0);
             } else {
-//                System.out.println("Filter: " + tableName + " is NOT in " + conditionString);
                 TableFilter temp = tableFilterList.get(0);
                 tableFilterList.remove(0);
                 tableFilterList.add(temp);
             }
         }
 
-        // add remaining tables back
-//        for (TableFilter filter : toRevisit) {
-//            list[insertIndex] = filter;
-//            insertIndex++;
-//        }
-
-
-        for (int i = 0; i < list.length; i++) {
-            System.out.println(list[i]);
-        }
         return list;
     }
 }

--- a/h2/src/main/org/h2/command/query/RuleBasedJoinOrderPicker.java
+++ b/h2/src/main/org/h2/command/query/RuleBasedJoinOrderPicker.java
@@ -27,8 +27,15 @@ public class RuleBasedJoinOrderPicker {
 
 
 //        Arrays.sort(filtersSorted, (a, b) -> Long.compare(a.getTable().getRowCountApproximation(session), b.getTable().getRowCountApproximation(session)));
+        String conditionString = "";
+        if (filters.length > 0) {
+            TableFilter temp = filters[0];
+            Expression fullCondition = temp.getFullCondition(); // all filters return the same condition
+            if (fullCondition != null) {
+                conditionString = fullCondition.toString();
+            }
+        }
 
-        String conditionString = filters[0].getFullCondition().toString(); // all filters return the same condition
         List<String> conditions = new ArrayList<>();
         // get content inside parenthesis
         Pattern pattern = Pattern.compile("\\(([^)]+)\\)");
@@ -37,7 +44,7 @@ public class RuleBasedJoinOrderPicker {
         while (matcher.find()) {
             String conditionInsideParentheses = matcher.group(1);   // only get inside of parenthesis
             conditions.add(conditionInsideParentheses);
-            System.out.println("Condition added: " + conditionInsideParentheses);
+//            System.out.println("Condition added: " + conditionInsideParentheses);
         }
 
         List<TableFilter> toRevisit = new ArrayList<>();                   // store Cartesian products here
@@ -50,10 +57,15 @@ public class RuleBasedJoinOrderPicker {
             boolean conditionSatisfied = false;
             if (insertIndex > 0 && !conditions.isEmpty()) {
                 for (String condition : conditions) {
-                    String tableNamePrev = list[insertIndex - 1].getTable().getName().replace("PUBLIC.", "");
+                    String tableNamePrev;
+                    if (list[insertIndex - 1] != null) {
+                        tableNamePrev = list[insertIndex - 1].getTable().getName().replace("PUBLIC.", "");
+                    } else {
+                        tableNamePrev = "";
+                    }
                     if (condition.contains(tableName) &&  condition.contains(tableNamePrev)) {
                         conditionSatisfied = true;
-                        System.out.println("Conditions is satisfied: " + conditionSatisfied);
+//                        System.out.println("Conditions is satisfied: " + conditionSatisfied);
                         break;
                     }
                 }
@@ -62,12 +74,12 @@ public class RuleBasedJoinOrderPicker {
                 conditionSatisfied = true;
             }
             if (conditionSatisfied) {
-                System.out.println("Filter: " + tableName + " is in " + conditionString);
+//                System.out.println("Filter: " + tableName + " is in " + conditionString);
                 list[insertIndex] = tableFilterList.get(0);
                 insertIndex++;
                 tableFilterList.remove(0);
             } else {
-                System.out.println("Filter: " + tableName + " is NOT in " + conditionString);
+//                System.out.println("Filter: " + tableName + " is NOT in " + conditionString);
                 TableFilter temp = tableFilterList.get(0);
                 tableFilterList.remove(0);
                 tableFilterList.add(temp);

--- a/h2/src/main/org/h2/command/query/RuleBasedJoinOrderPicker.java
+++ b/h2/src/main/org/h2/command/query/RuleBasedJoinOrderPicker.java
@@ -1,0 +1,22 @@
+package org.h2.command.query;
+
+import org.h2.engine.SessionLocal;
+import org.h2.table.TableFilter;
+
+/**
+ * Determines the best join order by following rules rather than considering every possible permutation.
+ */
+public class RuleBasedJoinOrderPicker {
+    final SessionLocal session;
+    final TableFilter[] filters;
+
+    public RuleBasedJoinOrderPicker(SessionLocal session, TableFilter[] filters) {
+        this.session = session;
+        this.filters = filters;
+    }
+
+    public TableFilter[] bestOrder() {
+        // TODO: implement rules
+        return filters;
+    }
+}

--- a/h2/src/main/org/h2/command/query/RuleBasedJoinOrderPicker.java
+++ b/h2/src/main/org/h2/command/query/RuleBasedJoinOrderPicker.java
@@ -2,6 +2,12 @@ package org.h2.command.query;
 
 import org.h2.engine.SessionLocal;
 import org.h2.table.TableFilter;
+import org.h2.expression.Expression;
+import java.util.Arrays;
+import java.util.List;
+import java.util.ArrayList;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * Determines the best join order by following rules rather than considering every possible permutation.
@@ -16,7 +22,68 @@ public class RuleBasedJoinOrderPicker {
     }
 
     public TableFilter[] bestOrder() {
-        // TODO: implement rules
-        return filters;
+        TableFilter[] list = new TableFilter[filters.length];
+        List<TableFilter> tableFilterList = new ArrayList<>(Arrays.asList(filters));
+
+
+//        Arrays.sort(filtersSorted, (a, b) -> Long.compare(a.getTable().getRowCountApproximation(session), b.getTable().getRowCountApproximation(session)));
+
+        String conditionString = filters[0].getFullCondition().toString(); // all filters return the same condition
+        List<String> conditions = new ArrayList<>();
+        // get content inside parenthesis
+        Pattern pattern = Pattern.compile("\\(([^)]+)\\)");
+        Matcher matcher = pattern.matcher(conditionString);
+        // get a list of conditions
+        while (matcher.find()) {
+            String conditionInsideParentheses = matcher.group(1);   // only get inside of parenthesis
+            conditions.add(conditionInsideParentheses);
+            System.out.println("Condition added: " + conditionInsideParentheses);
+        }
+
+        List<TableFilter> toRevisit = new ArrayList<>();                   // store Cartesian products here
+        int insertIndex = 0;
+        // add tables with lowest row count first that are not cartesian products
+        tableFilterList.sort((a, b) -> Long.compare(a.getTable().getRowCountApproximation(session), b.getTable().getRowCountApproximation(session)));
+        while(!tableFilterList.isEmpty()) {
+            // if table is not in the condition it is a cartesian product
+            String tableName = tableFilterList.get(0).getTable().getName().replace("PUBLIC.", "");
+            boolean conditionSatisfied = false;
+            if (insertIndex > 0 && !conditions.isEmpty()) {
+                for (String condition : conditions) {
+                    String tableNamePrev = list[insertIndex - 1].getTable().getName().replace("PUBLIC.", "");
+                    if (condition.contains(tableName) &&  condition.contains(tableNamePrev)) {
+                        conditionSatisfied = true;
+                        System.out.println("Conditions is satisfied: " + conditionSatisfied);
+                        break;
+                    }
+                }
+            }
+            if (insertIndex  == 0){
+                conditionSatisfied = true;
+            }
+            if (conditionSatisfied) {
+                System.out.println("Filter: " + tableName + " is in " + conditionString);
+                list[insertIndex] = tableFilterList.get(0);
+                insertIndex++;
+                tableFilterList.remove(0);
+            } else {
+                System.out.println("Filter: " + tableName + " is NOT in " + conditionString);
+                TableFilter temp = tableFilterList.get(0);
+                tableFilterList.remove(0);
+                tableFilterList.add(temp);
+            }
+        }
+
+        // add remaining tables back
+//        for (TableFilter filter : toRevisit) {
+//            list[insertIndex] = filter;
+//            insertIndex++;
+//        }
+
+
+        for (int i = 0; i < list.length; i++) {
+            System.out.println(list[i]);
+        }
+        return list;
     }
 }

--- a/h2/src/main/org/h2/table/TableFilter.java
+++ b/h2/src/main/org/h2/table/TableFilter.java
@@ -1264,6 +1264,15 @@ public class TableFilter implements ColumnResolver {
     }
 
     /**
+     * Retrieves the full condition expression.
+     *
+     * @return The complete condition represented as an {@code Expression} object.
+     */
+    public Expression getFullCondition(){
+        return fullCondition;
+    }
+
+    /**
      * A visitor for table filters.
      */
     public interface TableFilterVisitor {

--- a/h2/src/test/org/h2/command/query/RuleBasedJoinOrderPickerTest.java
+++ b/h2/src/test/org/h2/command/query/RuleBasedJoinOrderPickerTest.java
@@ -1,0 +1,215 @@
+package org.h2.command.query;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.h2.engine.Database;
+import org.h2.engine.SessionLocal;
+import org.h2.expression.Expression;
+import org.h2.expression.ExpressionColumn;
+import org.h2.expression.condition.BooleanTest;
+import org.h2.expression.condition.Comparison;
+import org.h2.expression.condition.ConditionAndOr;
+import org.h2.expression.condition.ConditionAndOrN;
+import org.h2.table.Table;
+import org.h2.table.TableFilter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class RuleBasedJoinOrderPickerTest {
+    SessionLocal mockSession;
+    Database mockDatabase;
+
+    RuleBasedJoinOrderPicker ruleBasedJoinOrderPicker;
+
+    Table customersTable;
+    Table locationsTable;
+    Table ordersTable;
+    Table orderLinesTable;
+
+    ExpressionColumn locationsLocationId;
+
+    ExpressionColumn customersCustomerId;
+    ExpressionColumn customersLocationId;
+
+    ExpressionColumn ordersOrderId;
+    ExpressionColumn ordersLocationId;
+    ExpressionColumn ordersCustomerId;
+
+    ExpressionColumn orderLinesOrderLineId;
+    ExpressionColumn orderLinesOrderId;
+    ExpressionColumn orderLinesLocationId;
+    ExpressionColumn orderLinesCustomerId;
+
+    @BeforeEach
+    public void setUp(){
+        mockSession = Mockito.mock(SessionLocal.class);
+        Mockito.when(mockSession.nextObjectId()).thenReturn(1);
+
+        mockDatabase = Mockito.mock(Database.class);
+
+        // for the purposes of this unit test, we will use four mock tables with
+        // multiple relationships between them
+        locationsTable = Mockito.mock(Table.class);
+        Mockito.when(locationsTable.getName()).thenReturn("locations");
+        Mockito.when(locationsTable.getRowCountApproximation(mockSession)).thenReturn(15L);
+
+        customersTable = Mockito.mock(Table.class);
+        Mockito.when(customersTable.getName()).thenReturn("customers");
+        Mockito.when(customersTable.getRowCountApproximation(mockSession)).thenReturn(50L);
+
+        ordersTable = Mockito.mock(Table.class);
+        Mockito.when(ordersTable.getName()).thenReturn("orders");
+        Mockito.when(ordersTable.getRowCountApproximation(mockSession)).thenReturn(1000L);
+
+        orderLinesTable = Mockito.mock(Table.class);
+        Mockito.when(orderLinesTable.getName()).thenReturn("orderLines");
+        Mockito.when(orderLinesTable.getRowCountApproximation(mockSession)).thenReturn(5000L);
+
+        // locations (15 rows)
+        //  -> location_id
+        locationsLocationId = Mockito.mock(ExpressionColumn.class);
+        Mockito.when(locationsLocationId.getTableName()).thenReturn("locations");
+        // customers (50 rows)
+        //  -> location_id
+        customersCustomerId = Mockito.mock(ExpressionColumn.class);
+        customersLocationId = Mockito.mock(ExpressionColumn.class);
+        Mockito.when(customersCustomerId.getTableName()).thenReturn("customers");
+        Mockito.when(customersLocationId.getTableName()).thenReturn("customers");
+        // orders (1,000 rows)
+        //  -> location_id
+        //  -> customer_id
+        ordersOrderId = Mockito.mock(ExpressionColumn.class);
+        ordersLocationId = Mockito.mock(ExpressionColumn.class);
+        ordersCustomerId = Mockito.mock(ExpressionColumn.class);
+        Mockito.when(ordersOrderId.getTableName()).thenReturn("orders");
+        Mockito.when(ordersLocationId.getTableName()).thenReturn("orders");
+        Mockito.when(ordersCustomerId.getTableName()).thenReturn("orders");
+        // order_lines (5,000)
+        //  -> order_id
+        //  -> location_id
+        //  -> customer_id
+        orderLinesOrderLineId = Mockito.mock(ExpressionColumn.class);
+        orderLinesOrderId = Mockito.mock(ExpressionColumn.class);
+        orderLinesLocationId = Mockito.mock(ExpressionColumn.class);
+        orderLinesCustomerId = Mockito.mock(ExpressionColumn.class);
+        Mockito.when(orderLinesOrderLineId.getTableName()).thenReturn("orderLines");
+        Mockito.when(orderLinesOrderId.getTableName()).thenReturn("orderLines");
+        Mockito.when(orderLinesLocationId.getTableName()).thenReturn("orderLines");
+        Mockito.when(orderLinesCustomerId.getTableName()).thenReturn("orderLines");
+    }
+
+    @Test
+    public void bestOrder_singleTable(){
+        TableFilter tableFilter = new TableFilter(mockSession, customersTable, "customers", true, null, 0, null);
+        tableFilter.setFullCondition(null);
+
+        List<TableFilter> expectedFilters = List.of(tableFilter);
+        TableFilter[] inputFilters = {tableFilter};
+
+        ruleBasedJoinOrderPicker = new RuleBasedJoinOrderPicker(mockSession, inputFilters);
+        List<TableFilter> result = Arrays.asList(ruleBasedJoinOrderPicker.bestOrder());
+
+        assertEquals(expectedFilters, result);
+    }
+
+    @Test
+    public void bestOrder_twoTablesSingleJoin(){
+        Expression locationsAndCustomers = new Comparison(
+                Comparison.EQUAL,
+                locationsLocationId,
+                customersLocationId,
+                false);
+
+        Expression fullCondition = new ConditionAndOrN(ConditionAndOr.AND,
+                List.of(
+                        locationsAndCustomers
+                )
+        );
+
+        TableFilter locationsFilter = new TableFilter(mockSession, locationsTable, "locations", true, null, 0, null);
+        locationsFilter.setFullCondition(fullCondition);
+
+        TableFilter customersFilter = new TableFilter(mockSession, customersTable, "customers", true, null, 0, null);
+        customersFilter.setFullCondition(fullCondition);
+
+        // locations is smaller so should go first
+        List<TableFilter> expectedFilters = List.of(locationsFilter, customersFilter);
+
+        TableFilter[] inputFilters = {customersFilter, locationsFilter};
+
+        ruleBasedJoinOrderPicker = new RuleBasedJoinOrderPicker(mockSession, inputFilters);
+        List<TableFilter> result = Arrays.asList(ruleBasedJoinOrderPicker.bestOrder());
+
+        assertEquals(expectedFilters, result);
+    }
+
+    @Test
+    public void bestOrder_threeTablesMultipleJoins(){
+        Expression fullCondition = new ConditionAndOrN(ConditionAndOr.AND,
+                List.of(
+                        new Comparison(Comparison.EQUAL, locationsLocationId, customersLocationId, false),
+                        new Comparison(Comparison.EQUAL, locationsLocationId, ordersLocationId, false),
+                        new Comparison(Comparison.EQUAL, customersCustomerId, ordersCustomerId, false)
+                )
+        );
+
+        TableFilter locationsFilter = new TableFilter(mockSession, locationsTable, "locations", true, null, 0, null);
+        locationsFilter.setFullCondition(fullCondition);
+
+        TableFilter customersFilter = new TableFilter(mockSession, customersTable, "customers", true, null, 0, null);
+        customersFilter.setFullCondition(fullCondition);
+
+        TableFilter ordersFilter = new TableFilter(mockSession, ordersTable, "orders", true, null, 0, null);
+        customersFilter.setFullCondition(fullCondition);
+
+        // size order is locations, customers, orders
+        List<TableFilter> expectedFilters = List.of(locationsFilter, customersFilter, ordersFilter);
+
+        TableFilter[] inputFilters = {customersFilter, ordersFilter, locationsFilter};
+
+        ruleBasedJoinOrderPicker = new RuleBasedJoinOrderPicker(mockSession, inputFilters);
+        List<TableFilter> result = Arrays.asList(ruleBasedJoinOrderPicker.bestOrder());
+
+        assertEquals(expectedFilters, result);
+    }
+
+    @Test
+    public void bestOrder_fourTablesMultipleJoins(){
+        Expression fullCondition = new ConditionAndOrN(ConditionAndOr.AND,
+                List.of(
+                        new Comparison(Comparison.EQUAL, locationsLocationId, customersLocationId, false),
+                        new Comparison(Comparison.EQUAL, locationsLocationId, ordersLocationId, false),
+                        new Comparison(Comparison.EQUAL, customersCustomerId, ordersCustomerId, false),
+                        new Comparison(Comparison.EQUAL, orderLinesLocationId, locationsLocationId, false),
+                        new Comparison(Comparison.EQUAL, orderLinesOrderId, ordersOrderId, false),
+                        new Comparison(Comparison.EQUAL, orderLinesCustomerId, customersCustomerId, false)
+                )
+        );
+
+        TableFilter locationsFilter = new TableFilter(mockSession, locationsTable, "locations", true, null, 0, null);
+        locationsFilter.setFullCondition(fullCondition);
+
+        TableFilter customersFilter = new TableFilter(mockSession, customersTable, "customers", true, null, 0, null);
+        customersFilter.setFullCondition(fullCondition);
+
+        TableFilter ordersFilter = new TableFilter(mockSession, ordersTable, "orders", true, null, 0, null);
+        ordersFilter.setFullCondition(fullCondition);
+
+        TableFilter orderLinesFilter = new TableFilter(mockSession, orderLinesTable, "orderLines", true, null, 0, null);
+        orderLinesFilter.setFullCondition(fullCondition);
+
+        // size order is locations, customers, orders, orderLines
+        List<TableFilter> expectedFilters = List.of(locationsFilter, customersFilter, ordersFilter, orderLinesFilter);
+
+        TableFilter[] inputFilters = {orderLinesFilter, customersFilter, ordersFilter, locationsFilter};
+
+        ruleBasedJoinOrderPicker = new RuleBasedJoinOrderPicker(mockSession, inputFilters);
+        List<TableFilter> result = Arrays.asList(ruleBasedJoinOrderPicker.bestOrder());
+
+        assertEquals(expectedFilters, result);
+    }
+}

--- a/h2/src/test/org/h2/command/query/RuleBasedJoinOrderPickerTest.java
+++ b/h2/src/test/org/h2/command/query/RuleBasedJoinOrderPickerTest.java
@@ -118,17 +118,8 @@ public class RuleBasedJoinOrderPickerTest {
 
     @Test
     public void bestOrder_twoTablesSingleJoin(){
-        Expression locationsAndCustomers = new Comparison(
-                Comparison.EQUAL,
-                locationsLocationId,
-                customersLocationId,
-                false);
-
-        Expression fullCondition = new ConditionAndOrN(ConditionAndOr.AND,
-                List.of(
-                        locationsAndCustomers
-                )
-        );
+        Expression fullCondition = Mockito.mock(Expression.class);
+        Mockito.when(fullCondition.toString()).thenReturn("(locations.LOCATIONS_ID = customers.LOCATIONS_ID)");
 
         TableFilter locationsFilter = new TableFilter(mockSession, locationsTable, "locations", true, null, 0, null);
         locationsFilter.setFullCondition(fullCondition);
@@ -149,13 +140,10 @@ public class RuleBasedJoinOrderPickerTest {
 
     @Test
     public void bestOrder_threeTablesMultipleJoins(){
-        Expression fullCondition = new ConditionAndOrN(ConditionAndOr.AND,
-                List.of(
-                        new Comparison(Comparison.EQUAL, locationsLocationId, customersLocationId, false),
-                        new Comparison(Comparison.EQUAL, locationsLocationId, ordersLocationId, false),
-                        new Comparison(Comparison.EQUAL, customersCustomerId, ordersCustomerId, false)
-                )
-        );
+        Expression fullCondition = Mockito.mock(Expression.class);
+        Mockito.when(fullCondition.toString()).thenReturn("((locations.LOCATION_ID = customers.LOCATION_ID)\nAND " +
+                "(locations.LOCATION_ID = orders.LOCATION_ID)\nAND " +
+                "(customers.CUSTOMER_ID = orders.CUSTOMER_ID))\n");
 
         TableFilter locationsFilter = new TableFilter(mockSession, locationsTable, "locations", true, null, 0, null);
         locationsFilter.setFullCondition(fullCondition);
@@ -179,17 +167,25 @@ public class RuleBasedJoinOrderPickerTest {
 
     @Test
     public void bestOrder_fourTablesMultipleJoins(){
-        Expression fullCondition = new ConditionAndOrN(ConditionAndOr.AND,
-                List.of(
-                        new Comparison(Comparison.EQUAL, locationsLocationId, customersLocationId, false),
-                        new Comparison(Comparison.EQUAL, locationsLocationId, ordersLocationId, false),
-                        new Comparison(Comparison.EQUAL, customersCustomerId, ordersCustomerId, false),
-                        new Comparison(Comparison.EQUAL, orderLinesLocationId, locationsLocationId, false),
-                        new Comparison(Comparison.EQUAL, orderLinesOrderId, ordersOrderId, false),
-                        new Comparison(Comparison.EQUAL, orderLinesCustomerId, customersCustomerId, false)
-                )
-        );
+//        Expression fullCondition = new ConditionAndOrN(ConditionAndOr.AND,
+//                List.of(
+//                        new Comparison(Comparison.EQUAL, locationsLocationId, customersLocationId, false),
+//                        new Comparison(Comparison.EQUAL, locationsLocationId, ordersLocationId, false),
+//                        new Comparison(Comparison.EQUAL, customersCustomerId, ordersCustomerId, false),
+//                        new Comparison(Comparison.EQUAL, orderLinesLocationId, locationsLocationId, false),
+//                        new Comparison(Comparison.EQUAL, orderLinesOrderId, ordersOrderId, false),
+//                        new Comparison(Comparison.EQUAL, orderLinesCustomerId, customersCustomerId, false)
+//                )
+//        );
+        Expression fullCondition = Mockito.mock(Expression.class);
+        String conditionString = "((locations.LOCATION_ID = customers.LOCATION_ID)\nAND " +
+                "(locations.LOCATION_ID = orders.LOCATION_ID)\nAND " +
+                "(customers.CUSTOMER_ID = orders.CUSTOMER_ID)\nAND " +
+                "(orderLines.LOCATION_ID = locations.LOCATION_ID)\nAND " +
+                "(orderLines.ORDER_ID = orders.ORDER_ID)\nAND " +
+                "(orderLines.CUSTOMER_ID = customers.CUSTOMER_ID))";
 
+        Mockito.when(fullCondition.toString()).thenReturn(conditionString);
         TableFilter locationsFilter = new TableFilter(mockSession, locationsTable, "locations", true, null, 0, null);
         locationsFilter.setFullCondition(fullCondition);
 


### PR DESCRIPTION
## Query from HW 4 Problem 4 
 
<screenshot of EXPLAIN ANALYZE>

![Screenshot 2025-03-27 at 11 21 13 PM](https://github.com/user-attachments/assets/b61ca421-019d-4fb3-87a3-9a2330744c1b)

```
row count of each table
-----------------------
users : 10000
followers : 995040
posts : 995086
```
The join order optimizer joins the tables in the order of users -> followers -> posts.  This is expected behavior because it is joining the tables with the least amount of rows first.
 
<your explanation on whether you are satisfied that the above explain plan confirms the code changes that you made>
 
## HW 5 : Query 1 - Single Table
 
![Screenshot 2025-03-28 at 2 17 16 AM](https://github.com/user-attachments/assets/a9bdcbfa-2741-49e5-bb49-286f56d18d8e)


<screenshot of EXPLAIN ANALYZE>
 
<your explanation on whether you are satisfied that the above explain plan confirms the code changes that you made>

I am satisfied with this result as I can confirm my code has not regressed the most basic query execution functionality.  However, since this query does not use any joins, it is not really testing any additional functionality that I have added.
 
## HW 5 : Query 2 - Just Two Tables
 
![Screenshot 2025-03-28 at 2 17 57 AM](https://github.com/user-attachments/assets/3d97b61d-7dca-4f56-b0c8-7770658060bd)


<screenshot of EXPLAIN ANALYZE>
 
<your explanation on whether you are satisfied that the above explain plan confirms the code changes that you made>

It looks like no regression has occurred even after performing a join :)

 
## HW 5 : Query 3 - Three Tables
 
<screenshot of EXPLAIN ANALYZE>

![Screenshot 2025-03-28 at 2 18 40 AM](https://github.com/user-attachments/assets/2af0bbad-4f41-419b-9553-64d1b207c673)

 
<your explanation on whether you are satisfied that the above explain plan confirms the code changes that you made>
 
It looks like my logic was able to avoid a Cartesian join in this example, so I am satisfied.
I am satisfied because nothing has regressed and we are still able to perform joins.

## HW 5 : Query 4 - Four Tables
 
![Screenshot 2025-03-28 at 2 19 44 AM](https://github.com/user-attachments/assets/f7c364b6-e61f-47a8-bbe7-4379d12decb9)

<screenshot of EXPLAIN ANALYZE>
 
<your explanation on whether you are satisfied that the above explain plan confirms the code changes that you made>
 
My rule based query optimizer has picked the optimal path based on the rules given. It avoided Cartesian join and joined based on row number.

## HW 5 : Query 5 - Five Tables
 
![Screenshot 2025-03-28 at 2 20 39 AM](https://github.com/user-attachments/assets/5367a6c8-7fe9-4e31-8dcc-15905264e98e)

<screenshot of EXPLAIN ANALYZE>
 
<your explanation on whether you are satisfied that the above explain plan confirms the code changes that you made>

I am satisfied because my optimizer has given the expected plan avoiding cartesian joins at all cost and starting with the smallest customers table. 

## HW 5 : Query 6 - Four Tables, More Options
 
<screenshot of EXPLAIN ANALYZE>
 
![Screenshot 2025-03-28 at 2 21 44 AM](https://github.com/user-attachments/assets/35d36da2-9a75-4fcf-8d14-8fe99a0ee15b)

<your explanation on whether you are satisfied that the above explain plan confirms the code changes that you made>

Optimizer returns expected plan avoiding Cartesian joins and choosing order_payments as the next table after order_details because it is smaller than orders. Satisfied.
 
## Our rule based optimizer is still fairly limited.  Can you think of a query in which it would perform a fairly catastrophic join order?
 

 
It would perform a catastrophic join order if there were multiple joins, and one of the tables with a lot of rows actually gets filters (for example through a WHERE clause). If this table were to be narrowed down to a few rows because of the filter, our rule based optimizer would be very efficient because it only takes into account the original number of rows of the tables.

## Our rule based optimizer is still fairly limited.  If you were to improve it, what additional rules would you include?
 
﻿

Some additional rules I would add are to check if there is an index to a table. If an index exists that would be used over doing a full table scan. Another rule would be to check how many rows exist after the table goes through a filter.   If the filter is used and then the table is joined we can rule out many intermediate results.